### PR TITLE
feat: Relax AWS provider version constraint

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,7 +1,7 @@
 terraform {
   required_version = "~>  1.0"
   required_providers {
-    aws     = "~>5.0"
+    aws     = ">=5.0"
     archive = "~>2.0"
   }
 }


### PR DESCRIPTION
This PR updates the AWS provider version constraint in `versions.tf` from `~>5.0` to `>=5.0` to allow for more flexible version updates while maintaining compatibility with AWS provider version 5 and above.

## Change Type

Indicate the type of changes in this pull request (required):

_Release will be generated_
- [ ] `Bug Fix`
- [x] `Enhancement`
- [ ] `Major Change`
- [ ] `Tests`
- [ ] `Miscellaneous`

_No release will be generated_
- [ ] `Build System`
- [ ] `Documentation`

_No release will be generated, even if combined with other labels_
- [ ] `Skip Release`