### PR TITLE
build(release-please): Update release-please configuration

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,7 +15,6 @@ jobs:
     name: release-please
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v3
+      - uses: googleapis/release-please-action@v4
         with:
           release-type: terraform-module
-          package-name: release-please-action


### PR DESCRIPTION
Update the release-please GitHub Action configuration to fix issues with the workflow setup.

## Changes

- Upgrade from deprecated `google-github-actions/release-please-action@v3` to `googleapis/release-please-action@v4`
- Remove incorrect `package-name` parameter which is not needed for terraform-module release type

## Change Type

Indicate the type of changes in this pull request (required):

_Release will be generated_
- [ ] `Bug Fix`
- [ ] `Enhancement`
- [ ] `Major Change`
- [ ] `Tests`
- [ ] `Miscellaneous`

_No release will be generated_
- [x] `Build System`
- [ ] `Documentation`

_No release will be generated, even if combined with other labels_
- [ ] `Skip Release`