### PR TITLE
docs: Update README with current version and usage clarification

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,14 @@ This Lambda Function forwards SNS messages to a CloudWatch Log Group.
 - Enables cloud-init, bootstraps and functions to easily write log entries to a centralized CloudWatch Log
 - Simplifies troubleshooting of solutions with decentralized logic
   - scripts and functions spread across instances, Lambda and services
-- Easily add instrumentation to scripts: `aws sns publish --topic-arn $TOPIC_ARN --message $LOG_ENTRY`
-  - Use with IAM instance policy requires `--region $AWS_REGION` parameter
+
+**Example Usage After Deployment:**
+
+Once the module is deployed, applications and scripts can send logs to CloudWatch by publishing to the created SNS topic:
+```bash
+aws sns publish --topic-arn $TOPIC_ARN --message $LOG_ENTRY
+```
+- When using with IAM instance policy, include the `--region $AWS_REGION` parameter
 
 
 
@@ -46,7 +52,7 @@ Usage
 ```hcl
 module "sns_logger" {
   source            = "ordinaryexperts/sns-cloudwatch-logs/aws"
-  version           = "~> 5.2"
+  version           = "~> 7.1"
 
   sns_topic_name    = "projectx-logging"
   log_group_name    = "projectx"


### PR DESCRIPTION
## Summary

This PR updates the README to reflect the current module version and clarifies the usage examples.

## Changes

- Updated the module version in the usage example from `~> 5.2` to `~> 7.1` to match the latest release
- Clarified that the AWS SNS publish command is an example of how to use the deployed infrastructure, not part of the Terraform module setup
- Added a clear "Example Usage After Deployment" section to prevent confusion

## Change Type

Indicate the type of changes in this pull request (required):

_Release will be generated_
- [ ] `Bug Fix`
- [ ] `Enhancement`
- [ ] `Major Change`
- [ ] `Tests`
- [ ] `Miscellaneous`

_No release will be generated_
- [ ] `Build System`
- [x] `Documentation`

_No release will be generated, even if combined with other labels_
- [ ] `Skip Release`