### PR TITLE
Fix: Process all SNS records in Lambda event

### DIFF
--- a/function/pyproject.toml
+++ b/function/pyproject.toml
@@ -42,4 +42,5 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "ruff>=0.12.5",
+    "types-pytz>=2025.2.0.20250516",
 ]

--- a/function/sns_cloudwatch_gw.py
+++ b/function/sns_cloudwatch_gw.py
@@ -27,21 +27,30 @@ def handler(event, context):
     )
     cwLogger.addHandler(cloudwatch_handler)
 
-    try:
-        # FIXME: What if there are more than one record?
-        # Currently only processes the first record in the event
-        # Lambda typically sends one SNS message per invocation, but this could change
-        message_source = event["Records"][0]["EventSource"]
-    except KeyError:
-        log.warn("Unexpected event format", lambda_event=event)
+    # Process all records in the event
+    if "Records" not in event:
+        log.warn("Unexpected event format - missing Records", lambda_event=event)
         return
 
-    if message_source == "aws:sns":
-        body = event["Records"][0]["Sns"]["Message"]
-        cwLogger.info(body)
-        cloudwatch_handler.flush()
-    else:
-        log.warn("Message source is not aws:sns", event=event)
+    for record in event["Records"]:
+        try:
+            message_source = record["EventSource"]
+        except KeyError:
+            log.warn("Unexpected record format - missing EventSource", record=record)
+            continue
+
+        if message_source == "aws:sns":
+            try:
+                body = record["Sns"]["Message"]
+                cwLogger.info(body)
+            except KeyError:
+                log.warn("Unexpected SNS record format - missing Sns.Message", record=record)
+                continue
+        else:
+            log.warn("Message source is not aws:sns", record=record)
+
+    # Flush after processing all records
+    cloudwatch_handler.flush()
 
     # Lambda doesn't require a specific return value for asynchronous invocations
     # Returning None indicates successful completion

--- a/function/tests/test_sns_cloudwatch_gw.py
+++ b/function/tests/test_sns_cloudwatch_gw.py
@@ -67,7 +67,7 @@ class TestHandler:
 
     @patch('sns_cloudwatch_gw.watchtower.CloudWatchLogHandler')
     def test_handler_multiple_records(self, mock_cw_handler_class, sns_event_multiple_records, lambda_context, mock_watchtower_handler):
-        """Test handling of multiple SNS records (only processes first)."""
+        """Test handling of multiple SNS records - should process all records."""
         mock_cw_handler_class.return_value = mock_watchtower_handler
         mock_cw_logger = MagicMock()
         
@@ -76,7 +76,12 @@ class TestHandler:
             
             result = sns_cloudwatch_gw.handler(sns_event_multiple_records, lambda_context)
             
-            mock_cw_logger.info.assert_called_once_with("First test log message")
+            # Verify both messages were logged
+            assert mock_cw_logger.info.call_count == 2
+            mock_cw_logger.info.assert_any_call("First test log message")
+            mock_cw_logger.info.assert_any_call("Second test log message")
+            
+            # Verify flush was called once after all records
             mock_watchtower_handler.flush.assert_called_once()
             
             assert result is None
@@ -93,7 +98,7 @@ class TestHandler:
             mock_log.warn.assert_called_once()
             call_args = mock_log.warn.call_args
             assert call_args[0][0] == "Message source is not aws:sns"
-            assert 'event' in call_args[1]
+            assert 'record' in call_args[1]
             
             assert result is None
 
@@ -108,7 +113,7 @@ class TestHandler:
             
             mock_log.warn.assert_called_once()
             call_args = mock_log.warn.call_args
-            assert call_args[0][0] == "Unexpected event format"
+            assert call_args[0][0] == "Unexpected event format - missing Records"
             assert 'lambda_event' in call_args[1]
             
             assert result is None
@@ -124,7 +129,7 @@ class TestHandler:
             
             mock_log.warn.assert_called_once()
             call_args = mock_log.warn.call_args
-            assert call_args[0][0] == "Unexpected event format"
+            assert call_args[0][0] == "Unexpected event format - missing Records"
             
             assert result is None
 
@@ -314,7 +319,10 @@ with patch('sns_cloudwatch_gw.handler') as mock_handler:
         with patch('sns_cloudwatch_gw.log', mock_log):
             result = sns_cloudwatch_gw.handler(event_no_source, lambda_context)
             
-            mock_log.warn.assert_called_once_with("Unexpected event format", lambda_event=event_no_source)
+            mock_log.warn.assert_called_once()
+            call_args = mock_log.warn.call_args
+            assert call_args[0][0] == "Unexpected record format - missing EventSource"
+            assert 'record' in call_args[1]
             assert result is None
 
     @pytest.mark.parametrize("env_level,expected_level", [
@@ -368,6 +376,99 @@ with patch('sns_cloudwatch_gw.handler') as mock_handler:
             
             mock_cw_logger.info.assert_called_once_with(message_content)
             assert result is None
+
+
+    @patch('sns_cloudwatch_gw.watchtower.CloudWatchLogHandler')
+    def test_handler_mixed_event_sources(self, mock_cw_handler_class, lambda_context, mock_watchtower_handler):
+        """Test handling of event with mixed SNS and non-SNS records."""
+        mixed_event = {
+            "Records": [
+                {
+                    "EventSource": "aws:sns",
+                    "Sns": {
+                        "Message": "SNS message 1"
+                    }
+                },
+                {
+                    "EventSource": "aws:s3",
+                    "s3": {
+                        "bucket": {"name": "test-bucket"}
+                    }
+                },
+                {
+                    "EventSource": "aws:sns",
+                    "Sns": {
+                        "Message": "SNS message 2"
+                    }
+                }
+            ]
+        }
+        
+        mock_cw_handler_class.return_value = mock_watchtower_handler
+        mock_cw_logger = MagicMock()
+        mock_log = MagicMock()
+        
+        with patch('sns_cloudwatch_gw.logging.getLogger') as mock_get_logger:
+            with patch('sns_cloudwatch_gw.log', mock_log):
+                mock_get_logger.return_value = mock_cw_logger
+                
+                result = sns_cloudwatch_gw.handler(mixed_event, lambda_context)
+                
+                # Should log two SNS messages
+                assert mock_cw_logger.info.call_count == 2
+                mock_cw_logger.info.assert_any_call("SNS message 1")
+                mock_cw_logger.info.assert_any_call("SNS message 2")
+                
+                # Should warn about one non-SNS record
+                mock_log.warn.assert_called_once()
+                assert mock_log.warn.call_args[0][0] == "Message source is not aws:sns"
+                
+                mock_watchtower_handler.flush.assert_called_once()
+                assert result is None
+
+    @patch('sns_cloudwatch_gw.watchtower.CloudWatchLogHandler')
+    def test_handler_sns_record_missing_message(self, mock_cw_handler_class, lambda_context, mock_watchtower_handler):
+        """Test handling of SNS record missing the Message field."""
+        event_no_message = {
+            "Records": [
+                {
+                    "EventSource": "aws:sns",
+                    "Sns": {
+                        "Type": "Notification"
+                        # Missing "Message" field
+                    }
+                }
+            ]
+        }
+        
+        mock_cw_handler_class.return_value = mock_watchtower_handler
+        mock_log = MagicMock()
+        
+        with patch('sns_cloudwatch_gw.log', mock_log):
+            result = sns_cloudwatch_gw.handler(event_no_message, lambda_context)
+            
+            mock_log.warn.assert_called_once()
+            call_args = mock_log.warn.call_args
+            assert call_args[0][0] == "Unexpected SNS record format - missing Sns.Message"
+            assert 'record' in call_args[1]
+            
+            mock_watchtower_handler.flush.assert_called_once()
+            assert result is None
+
+    @patch('sns_cloudwatch_gw.watchtower.CloudWatchLogHandler')
+    def test_handler_empty_records_list(self, mock_cw_handler_class, lambda_context, mock_watchtower_handler):
+        """Test handling of event with empty Records list."""
+        empty_records_event = {
+            "Records": []
+        }
+        
+        mock_cw_handler_class.return_value = mock_watchtower_handler
+        
+        result = sns_cloudwatch_gw.handler(empty_records_event, lambda_context)
+        
+        # Should handle gracefully - just flush without logging anything
+        mock_watchtower_handler.flush.assert_called_once()
+        assert result is None
 
 
 class TestMainExecution:

--- a/function/uv.lock
+++ b/function/uv.lock
@@ -329,6 +329,7 @@ dev = [
 [package.dev-dependencies]
 dev = [
     { name = "ruff" },
+    { name = "types-pytz" },
 ]
 
 [package.metadata]
@@ -349,7 +350,10 @@ requires-dist = [
 provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.12.5" }]
+dev = [
+    { name = "ruff", specifier = ">=0.12.5" },
+    { name = "types-pytz", specifier = ">=2025.2.0.20250516" },
+]
 
 [[package]]
 name = "markupsafe"
@@ -741,6 +745,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/eb/79/72064e6a701c2183016abbbfedaba506d81e30e232a68c9f0d6f6fcd1574/traitlets-5.14.3.tar.gz", hash = "sha256:9ed0579d3502c94b4b3732ac120375cda96f923114522847de4b3bb98b96b6b7", size = 161621, upload-time = "2024-04-19T11:11:49.746Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/00/c0/8f5d070730d7836adc9c9b6408dec68c6ced86b304a9b26a14df072a6e8c/traitlets-5.14.3-py3-none-any.whl", hash = "sha256:b74e89e397b1ed28cc831db7aea759ba6640cb3de13090ca145426688ff1ac4f", size = 85359, upload-time = "2024-04-19T11:11:46.763Z" },
+]
+
+[[package]]
+name = "types-pytz"
+version = "2025.2.0.20250516"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bd/72/b0e711fd90409f5a76c75349055d3eb19992c110f0d2d6aabbd6cfbc14bf/types_pytz-2025.2.0.20250516.tar.gz", hash = "sha256:e1216306f8c0d5da6dafd6492e72eb080c9a166171fa80dd7a1990fd8be7a7b3", size = 10940, upload-time = "2025-05-16T03:07:01.91Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c1/ba/e205cd11c1c7183b23c97e4bcd1de7bc0633e2e867601c32ecfc6ad42675/types_pytz-2025.2.0.20250516-py3-none-any.whl", hash = "sha256:e0e0c8a57e2791c19f718ed99ab2ba623856b11620cb6b637e5f62ce285a7451", size = 10136, upload-time = "2025-05-16T03:07:01.075Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where the Lambda function only processed the first SNS record in an event, potentially dropping messages when multiple records were batched together.

### Changes:
- Modified the Lambda handler to iterate through all records in `event["Records"]` instead of just processing the first one
- Added comprehensive test coverage to verify multiple records are processed correctly
- Added types-pytz dependency for improved type checking with mypy

### Context:
Previously, the code had a FIXME comment noting that only the first record was processed. This could lead to message loss in production when AWS batches multiple SNS messages into a single Lambda invocation.

## Change Type

Indicate the type of changes in this pull request (required):

_Release will be generated_
- [x] `Bug Fix`
- [ ] `Enhancement`
- [ ] `Major Change`
- [ ] `Tests`
- [ ] `Miscellaneous`

_No release will be generated_
- [ ] `Build System`
- [ ] `Documentation`

_No release will be generated, even if combined with other labels_
- [ ] `Skip Release`