### PR TITLE
feat: Prevent SNS messages from being double-logged to Lambda logs

### DIFF
--- a/function/sns_cloudwatch_gw.py
+++ b/function/sns_cloudwatch_gw.py
@@ -20,6 +20,8 @@ def handler(event: Dict[str, Any], context: Any) -> None:
 
     cwLogger = logging.getLogger("cloudwatch")
     cwLogger.setLevel(logging.INFO)
+    # Prevent propagation to root logger to avoid double logging
+    cwLogger.propagate = False
     cloudwatch_log_group = env.str("LOG_GROUP")
     now = datetime.datetime.now(pytz.utc)
     cloudwatch_log_stream = now.strftime("%Y-%m-%d/%H-%M")

--- a/function/tests/test_sns_cloudwatch_gw.py
+++ b/function/tests/test_sns_cloudwatch_gw.py
@@ -486,6 +486,8 @@ with patch('sns_cloudwatch_gw.handler') as mock_handler:
         mock_root_logger.info.assert_not_called()
         
         # Verify no handlers were added to root logger for SNS messages
+        # This check ensures that the CloudWatch handler is isolated to the "cloudwatch" logger
+        # and not inadvertently attached to the root logger, which would cause double logging
         assert len(root_handlers) == 0
 
     @patch('sns_cloudwatch_gw.watchtower.CloudWatchLogHandler')

--- a/function/tests/test_sns_cloudwatch_gw.py
+++ b/function/tests/test_sns_cloudwatch_gw.py
@@ -457,6 +457,38 @@ with patch('sns_cloudwatch_gw.handler') as mock_handler:
             assert result is None
 
     @patch('sns_cloudwatch_gw.watchtower.CloudWatchLogHandler')
+    @patch('sns_cloudwatch_gw.logging.getLogger')
+    def test_handler_no_double_logging(self, mock_get_logger, mock_cw_handler_class, sns_event, lambda_context, mock_watchtower_handler):
+        """Test that SNS messages are not propagated to root logger (no double logging)."""
+        # Create both cloudwatch logger and root logger mocks
+        mock_cw_logger = create_mock_logger()
+        mock_root_logger = create_mock_logger()
+        
+        # Configure getLogger to return different loggers based on name
+        def get_logger_side_effect(name=None):
+            if name == "cloudwatch":
+                return mock_cw_logger
+            return mock_root_logger
+            
+        mock_get_logger.side_effect = get_logger_side_effect
+        setup_cloudwatch_handler_mock(mock_cw_handler_class, mock_watchtower_handler)
+        
+        # Capture any handlers added to root logger
+        root_handlers = []
+        mock_root_logger.addHandler.side_effect = lambda h: root_handlers.append(h)
+        
+        sns_cloudwatch_gw.handler(sns_event, lambda_context)
+        
+        # Verify SNS message was logged to cloudwatch logger
+        mock_cw_logger.info.assert_called_once_with("This is a test log message from SNS")
+        
+        # Verify root logger did NOT receive the SNS message
+        mock_root_logger.info.assert_not_called()
+        
+        # Verify no handlers were added to root logger for SNS messages
+        assert len(root_handlers) == 0
+
+    @patch('sns_cloudwatch_gw.watchtower.CloudWatchLogHandler')
     def test_handler_empty_records_list(self, mock_cw_handler_class, lambda_context, mock_watchtower_handler):
         """Test handling of event with empty Records list."""
         empty_records_event = {


### PR DESCRIPTION
## Summary

This PR fixes issue #14 where SNS events were being logged both to their designated CloudWatch log stream and to the Lambda function's default logs at `/aws/lambda/FUNCNAME`.

The fix sets `propagate=False` on the CloudWatch logger to prevent SNS messages from propagating to the root logger. This ensures SNS events only appear in their intended destination while debug logging from the Lambda function continues to work normally.

**Important**: This fix only affects SNS message logging. Debug logging from the Lambda function itself (via structlog) continues to work as expected and will still appear in the Lambda function's default logs at `/aws/lambda/FUNCNAME`.

* Closes #14

## Changes

- Added `cwLogger.propagate = False` to prevent log propagation
- Added test to verify SNS messages don't propagate to root logger
- Added explanatory comment in test to clarify the purpose of checking root logger handlers

## Testing

- All existing tests pass with 100% coverage
- Added new test `test_handler_no_double_logging` to verify the fix works correctly

## Change Type

Indicate the type of changes in this pull request (required):

_Release will be generated_
- [x] `Bug Fix`
- [ ] `Enhancement`
- [ ] `Major Change`
- [ ] `Tests`
- [ ] `Miscellaneous`

_No release will be generated_
- [ ] `Build System`
- [ ] `Documentation`

_No release will be generated, even if combined with other labels_
- [ ] `Skip Release`